### PR TITLE
Add Conversations tab UI with placeholders

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,7 @@
         <button class="tab-btn" data-main-tab="deploy">Deploy</button>
         <button class="tab-btn" data-main-tab="browser">Browser</button>
         <button class="tab-btn" data-main-tab="telemetry">Telemetria</button>
+        <button class="tab-btn" data-main-tab="conversations">Conversas</button>
         <button class="tab-btn" data-main-tab="history">Histórico</button>
       </nav>
 
@@ -535,6 +536,92 @@ Nenhum registro de pipeline para este worker ainda.
             </select>
           </div>
           <pre class="mono-log" id="telemetryPre">—</pre>
+        </div>
+      </section>
+
+      <!-- =========================
+           TAB: CONVERSAS
+      ========================== -->
+      <section class="tab-panel" data-tab="conversations">
+        <div class="conversations-layout">
+          <div class="conversations-card">
+            <div class="conversations-header">
+              <div>
+                <div class="conversations-title">Leads</div>
+                <div class="conversations-subtitle">Pipeline ativo (estático)</div>
+              </div>
+              <span class="pill">5 ativos</span>
+            </div>
+            <div class="conversations-list">
+              <div class="conversation-item active">
+                <div class="conversation-name">João Santos</div>
+                <div class="conversation-meta">
+                  <span class="pill">Novo</span>
+                  <span class="conversation-time">Há 2 min</span>
+                </div>
+                <div class="conversation-preview">Perguntou sobre apartamentos no Centro.</div>
+              </div>
+              <div class="conversation-item">
+                <div class="conversation-name">Marina Lopes</div>
+                <div class="conversation-meta">
+                  <span class="pill">Qualificado</span>
+                  <span class="conversation-time">Há 18 min</span>
+                </div>
+                <div class="conversation-preview">Quer agendar visita para sábado.</div>
+              </div>
+              <div class="conversation-item">
+                <div class="conversation-name">Carlos Prado</div>
+                <div class="conversation-meta">
+                  <span class="pill">Retorno</span>
+                  <span class="conversation-time">Hoje</span>
+                </div>
+                <div class="conversation-preview">Solicitou simulação de financiamento.</div>
+              </div>
+              <div class="conversation-item">
+                <div class="conversation-name">Ana Ribeiro</div>
+                <div class="conversation-meta">
+                  <span class="pill">Em análise</span>
+                  <span class="conversation-time">Ontem</span>
+                </div>
+                <div class="conversation-preview">Comparando opções com 2 quartos.</div>
+              </div>
+              <div class="conversation-item">
+                <div class="conversation-name">Henrique Dias</div>
+                <div class="conversation-meta">
+                  <span class="pill">Follow-up</span>
+                  <span class="conversation-time">15/01</span>
+                </div>
+                <div class="conversation-preview">Pediu detalhes do condomínio.</div>
+              </div>
+            </div>
+          </div>
+
+          <div class="conversations-card conversation-thread">
+            <div class="conversations-header">
+              <div>
+                <div class="conversations-title">Thread</div>
+                <div class="conversations-subtitle">João Santos • WhatsApp</div>
+              </div>
+              <span class="pill">Aberta</span>
+            </div>
+            <div class="conversation-messages">
+              <div class="conversation-message incoming">
+                Olá! Vi um anúncio no Centro e queria saber se ainda está disponível.
+              </div>
+              <div class="conversation-message outgoing">
+                Oi João! Sim, ainda temos unidades. Posso te enviar opções com preço e metragem?
+              </div>
+              <div class="conversation-message incoming">
+                Pode sim. Prefiro algo com 2 quartos e garagem.
+              </div>
+              <div class="conversation-message outgoing">
+                Perfeito! Vou separar algumas opções e te retorno em breve.
+              </div>
+            </div>
+            <div class="conversation-composer">
+              <div class="composer-placeholder">Campo de resposta (em breve)</div>
+            </div>
+          </div>
         </div>
       </section>
 

--- a/style.css
+++ b/style.css
@@ -560,6 +560,7 @@ html, body {
 .main-area[data-current-tab="deploy"] .tab-panel[data-tab="deploy"],
 .main-area[data-current-tab="browser"] .tab-panel[data-tab="browser"],
 .main-area[data-current-tab="telemetry"] .tab-panel[data-tab="telemetry"],
+.main-area[data-current-tab="conversations"] .tab-panel[data-tab="conversations"],
 .main-area[data-current-tab="history"] .tab-panel[data-tab="history"]{
   display: block;
 }
@@ -1401,6 +1402,137 @@ body { overflow: hidden; }
   border: 0;
   border-radius: 18px;
   background: #0b0f15;
+}
+
+/* ============================================================
+   CONVERSAS
+============================================================ */
+.conversations-layout{
+  width: 100%;
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 14px;
+  padding: 12px 14px 14px;
+  overflow: hidden;
+}
+
+.conversations-card{
+  border: 1px solid #1e2230;
+  border-radius: 14px;
+  background: rgba(12,15,21,0.92);
+  padding: 14px;
+  box-shadow: 0 12px 26px rgba(0,0,0,0.35);
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.conversations-header{
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.conversations-title{
+  font-size: 13px;
+  font-weight: 600;
+  color: #e6e8eb;
+}
+
+.conversations-subtitle{
+  font-size: 12px;
+  color: #7f8896;
+  margin-top: 4px;
+}
+
+.conversations-list{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.conversation-item{
+  border: 1px solid #1e2230;
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #0f1115;
+  display: grid;
+  gap: 6px;
+}
+
+.conversation-item.active{
+  border-color: rgba(90,167,255,.55);
+  box-shadow: 0 0 0 1px rgba(90,167,255,.14);
+}
+
+.conversation-name{
+  font-size: 13px;
+  font-weight: 600;
+  color: #e6e8eb;
+}
+
+.conversation-meta{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  color: #8b93a2;
+}
+
+.conversation-time{
+  color: #6f7785;
+}
+
+.conversation-preview{
+  font-size: 12px;
+  color: #9aa0a6;
+}
+
+.conversation-thread{
+  gap: 10px;
+}
+
+.conversation-messages{
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.conversation-message{
+  max-width: 70%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-size: 12px;
+  line-height: 1.4;
+  color: #e6e8eb;
+}
+
+.conversation-message.incoming{
+  background: rgba(255,255,255,0.06);
+  align-self: flex-start;
+}
+
+.conversation-message.outgoing{
+  background: rgba(90,167,255,.15);
+  border: 1px solid rgba(90,167,255,.3);
+  align-self: flex-end;
+}
+
+.conversation-composer{
+  border-top: 1px solid #1e2230;
+  padding-top: 12px;
+}
+
+.composer-placeholder{
+  border: 1px dashed #2b3242;
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 12px;
+  color: #6f7785;
+  background: rgba(8,11,16,0.6);
 }
 
 /* BROWSER: reorganizar os botões/indicadores (AO VIVO em destaque) */


### PR DESCRIPTION
### Motivation
- Provide a safe, UI-only entry point for future conversations features by adding a new tab that does not depend on backend or new libraries. 
- Make the UI consistent with existing cards and layout patterns so the new tab can be iterated later without touching app state or handlers.

### Description
- Added a new main tab labelled "Conversas" and a corresponding `tab-panel` with a two-column placeholder layout (lead list on the left, thread on the right) into `index.html`.
- Implemented styles for the new layout that reuse the existing card visual language by adding rules in `style.css` (cards, header, list items, message bubbles, composer placeholder) and updated the visible-tab selector to include the new tab.
- Kept all state and handlers untouched; panel state remains in `panel-state.js`, tab switching is handled by the existing `initMainTabs` logic in `script.js`, and buttons/actions keep using `buttons-controller.js` as before.
- Files changed: `index.html`, `style.css`.

### Testing
- Automated tests: attempted an automated UI snapshot via Playwright which timed out and did not complete; no automated tests were modified or added because this is a UI-only change with static placeholders.
- Manual/browser validation steps (recommended):
  1. Start a local static server at the repository root, e.g. `python -m http.server 8000`.
  2. Open `http://localhost:8000/index.html` in a browser.
  3. Click the "Conversas" tab in the top tabs bar and confirm a two-column panel appears showing a lead list (left) and a thread (right) with static placeholder content.
  4. Switch between other tabs (Diretor / Deploy / Browser / Telemetria / Histórico) and confirm no visual regressions or console errors.
- Outcome: UI-only changes added and visible; automated screenshot attempt failed due to Playwright timeout but manual validation steps above should reproduce and validate the change.

Rollback plan
- Revert the UI changes by restoring the previous versions of `index.html` and `style.css` (for example by undoing the change in your SCM) and redeploy; this will remove the Conversations tab and styles immediately.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981362db398832d9e6bb34f720d98e4)